### PR TITLE
Removeing "view past campers" from index.php

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -46,7 +46,6 @@ and more flexability than object-fit -->
       <a class="facebook" href="https://www.facebook.com/compcamps"><i class="fa fa-3x fa-facebook"></i></a>
     </p>
     <br/>
-    <a href="campers.php">View Past Campers</a>
   </div>
 </section>
 


### PR DESCRIPTION
While theirs an option top right that takes you to the past campers, this is obsolete.